### PR TITLE
Check for missed_labels > 0

### DIFF
--- a/scripts/required_scripts.R
+++ b/scripts/required_scripts.R
@@ -212,10 +212,12 @@ cell_assignment_from_groups_of_cell_types <- function(updated_nomenclature,cell_
   ## Find the corresponding cell types for those cell sets
   labsL <- list()
   cs_digits <- max(3,nchar(dim(updated_nomenclature)[1]))
-  for (i in 1:length(missed_labels)){
-    m   <- eval(parse(text=paste("c(",gsub("-",":",gsub(missed_class[i],"",missed_labels[i])),")")))
-    m   <- substr(10^cs_digits+m,2,100)
-    labsL[[missed_labels[i]]] <- paste(missed_class[i],m)
+  if (length(missed_labels)>0){
+    for (i in 1:length(missed_labels)){
+      m   <- eval(parse(text=paste("c(",gsub("-",":",gsub(missed_class[i],"",missed_labels[i])),")")))
+      m   <- substr(10^cs_digits+m,2,100)
+      labsL[[missed_labels[i]]] <- paste(missed_class[i],m)
+    }
   }
   
   ## Now annotate them!


### PR DESCRIPTION
Hi @jeremymiller 

I ran into an error here running
```
> mapping <- cell_assignment_from_groups_of_cell_types(updated_nomenclature,cell_id,mapping)
Error in gsub(missed_class[i], "", missed_labels[i]) : 
  invalid 'pattern' argument
> 
```
https://github.com/AllenInstitute/nomenclature/blob/master/scripts/build_annotation_tables.rmd#L302-L308

The issue was that `missed_labels` is empty.


Note that I did read in the example data file `cell_metadata_MTG.csv` for this portion: 

https://github.com/AllenInstitute/nomenclature/blob/master/scripts/build_annotation_tables.rmd#L276-L279
```
# Read in metadata and collect correct columns for sample name and cell set accession id
metadata  <- read.csv("data/cell_metadata.csv")
samples   <- metadata$sample_name
```

It's very possible I've misunderstood something of course